### PR TITLE
Make backup_appdata work if container needs file binds

### DIFF
--- a/extra-scripts/backup_appdata.sh
+++ b/extra-scripts/backup_appdata.sh
@@ -182,6 +182,10 @@ create_backup() {
     # Create the backup file name
     backup_file="$(realpath -s "$destination_dir")/$(date +%F)@$now/$container_name"
     # Go to the source directory
+    # Check if source_dir is a directory, if not, strip the filename
+    if [ ! -d "$source_dir" ]; then
+        source_dir=$(dirname "$source_dir")
+    fi
     cd "$source_dir"/.. || return 
     # Get the name of the source directory
     source_dir=$(basename "$source_dir")


### PR DESCRIPTION
In rare cases a container image requires binding a file directly, which the script takes as source_dir for the backup. This adds a check, if the directory the scripts grabs is a filename and strips the filename.

i.e. ./backup_appdata.sh: line 185: cd: /appdata/container/container.conf/..: Not a directory stripes the filename (container.conf), so the script backups /appdata/container/ and its content properly.